### PR TITLE
fix: stack overflow in FileFormat, more idiomatic Rust

### DIFF
--- a/src/file_readers.rs
+++ b/src/file_readers.rs
@@ -16,9 +16,8 @@ pub struct FileReader {
 }
 
 impl FileReader {
-    pub fn new<T: AsRef<std::path::Path>>(path_name: T) -> Self {
-        let format: FileFormat = FileFormat::parse(path_name);
-        Self { format }
+    pub fn new<T: AsRef<std::path::Path>>(path_name: T) -> Result<Self, crate::Error> {
+        FileFormat::parse(path_name).map(|format| Self { format })
     }
 
     pub fn read_all_frames(&self) -> Vec<Frame> {

--- a/src/file_readers/frame_readers.rs
+++ b/src/file_readers/frame_readers.rs
@@ -22,10 +22,6 @@ impl FileFormat {
                 "Folder {:} is not frame readable",
                 path.to_str().unwrap_or_default().to_string()
             ),
-            Self::Unknown(path) => panic!(
-                "Folder {:} is not frame readable",
-                path.to_str().unwrap_or_default().to_string()
-            ),
         };
         result
     }

--- a/src/file_readers/spectrum_readers.rs
+++ b/src/file_readers/spectrum_readers.rs
@@ -22,10 +22,6 @@ impl FileFormat {
             Self::MS2Folder(path) => Box::new(MiniTDFReader::new(
                 path.to_str().unwrap_or_default().to_string(),
             )) as Box<dyn ReadableSpectra>,
-            Self::Unknown(path) => panic!(
-                "Folder {:} is not spectrum readable",
-                path.to_str().unwrap_or_default().to_string()
-            ),
         };
         result
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,3 +32,18 @@ pub use crate::{
     precursors::{Precursor, PrecursorType},
     spectra::{RawSpectrum, Spectrum},
 };
+
+#[derive(Debug)]
+pub enum Error {
+    UnknownFileFormat
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::UnknownFileFormat => f.write_str("unknown file format"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 use std::env;
-use timsrust::{FileReader, Spectrum};
+use timsrust::{FileReader, Spectrum, Error};
 
-fn main() {
+fn main() -> Result<(), Error> {
     let args: Vec<String> = env::args().collect();
     let d_folder_name: &str = &args[1];
-    let x = FileReader::new(d_folder_name.to_string());
+    let x = FileReader::new(d_folder_name.to_string())?;
     let dda_spectra: Vec<Spectrum> = x.read_all_spectra();
     let precursor_index: usize;
     if args.len() >= 3 {
@@ -24,4 +24,6 @@ fn main() {
     );
     println!("precursor {:?}", dda_spectra[precursor_index].mz_values);
     println!("precursor {:?}", dda_spectra[precursor_index].intensities);
+
+    Ok(())
 }

--- a/tests/frame_readers.rs
+++ b/tests/frame_readers.rs
@@ -15,7 +15,7 @@ fn tdf_reader_frames() {
         .to_str()
         .unwrap()
         .to_string();
-    let frames: Vec<Frame> = FileReader::new(file_path).read_all_frames();
+    let frames: Vec<Frame> = FileReader::new(file_path).unwrap().read_all_frames();
     let expected: Vec<Frame> = vec![
         Frame {
             scan_offsets: vec![0, 1, 3, 6, 10],

--- a/tests/spectrum_readers.rs
+++ b/tests/spectrum_readers.rs
@@ -15,7 +15,7 @@ fn minitdf_reader() {
         .to_str()
         .unwrap()
         .to_string();
-    let spectra: Vec<Spectrum> = FileReader::new(file_path).read_all_spectra();
+    let spectra: Vec<Spectrum> = FileReader::new(file_path).unwrap().read_all_spectra();
     let expected: Vec<Spectrum> = vec![
         Spectrum {
             mz_values: vec![100.0, 200.002, 300.03, 400.4],
@@ -59,7 +59,7 @@ fn tdf_reader_dda() {
         .to_str()
         .unwrap()
         .to_string();
-    let spectra: Vec<Spectrum> = FileReader::new(file_path).read_all_spectra();
+    let spectra: Vec<Spectrum> = FileReader::new(file_path).unwrap().read_all_spectra();
     let expected: Vec<Spectrum> = vec![
         Spectrum {
             mz_values: vec![199.7633445943076],


### PR DESCRIPTION
This PR does some initial refactoring of the `FileFormat` interface in an effort to make the library more in line with idiomatic Rust code. My suggestion would be to avoid panics in the library at all cost, instead preferring to propagate errors.

 Sage, for instance, is designed to allow failure of file reading - if you are searching 1000 files, you don't want a failure reading file #999 (or an invalid file path) to cause the entire search to fail; instead an error is reported and that file is skipped.

This PR also fixes a stack overflow (from unlimited recursion) that occurs when the the path does not contain ".d" or ".ms2"