### PR TITLE
Exposing traits that allow mz conversion and added selective DIA reading

### DIFF
--- a/src/file_readers.rs
+++ b/src/file_readers.rs
@@ -5,11 +5,11 @@ mod file_formats;
 mod frame_readers;
 mod spectrum_readers;
 
+pub use self::frame_readers::tdf_reader::TDFReader;
+pub use self::frame_readers::ReadableFrames;
+
 use {
-    self::{
-        file_formats::FileFormat, frame_readers::ReadableFrames,
-        spectrum_readers::ReadableSpectra,
-    },
+    self::{file_formats::FileFormat, spectrum_readers::ReadableSpectra},
     crate::{Frame, Spectrum},
 };
 

--- a/src/file_readers/common/sql_reader.rs
+++ b/src/file_readers/common/sql_reader.rs
@@ -27,18 +27,36 @@ impl SqlReader {
             "SELECT {} FROM {} ORDER BY {}",
             column_name, table_name, order_by
         );
-        let mut stmt: Statement = connection.prepare(&query).unwrap();
-        let rows = stmt
-            .query_map(
-                [],
-                // |row| row.get::<usize, T>(0)
-                |row| match row.get::<usize, T>(0) {
-                    Ok(value) => Ok(value),
-                    _ => Ok(T::default()),
-                },
-            )
-            .unwrap();
-        rows.collect::<Result<Vec<T>>>().unwrap()
+        let stmt: Result<Statement> = connection.prepare(&query);
+        let rows = match stmt {
+            Ok(mut statement) => {
+                let rows = statement
+                    .query_map(
+                        [],
+                        // |row| row.get::<usize, T>(0)
+                        |row| match row.get::<usize, T>(0) {
+                            Ok(value) => Ok(value),
+                            _ => Ok(T::default()),
+                        },
+                    )
+                    .unwrap()
+                    .collect::<Result<Vec<T>>>()
+                    .unwrap();
+                rows
+            },
+            // Note: This error happens mainly on the testing data, where
+            // some of the dia info tables are missing.
+            Err(error) => {
+                println!(
+                    "Error Reading sql `{}.{}`: {}",
+                    table_name, column_name, error
+                );
+                println!("Defaulting to empty vector");
+                let rows = Vec::new();
+                rows
+            },
+        };
+        rows
     }
 
     fn get_table_columns(&self, table_name: &str) -> Result<Vec<String>> {

--- a/src/file_readers/common/sql_reader/tables/dia_frames_msms.rs
+++ b/src/file_readers/common/sql_reader/tables/dia_frames_msms.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::file_readers::common::sql_reader::{ReadableFromSql, SqlReader};
 
 #[derive(Debug)]
@@ -7,6 +9,14 @@ pub struct DiaFramesMsMsTable {
     pub scan_end: Vec<u16>,
     pub mz_center: Vec<f64>,
     pub mz_width: Vec<f64>,
+}
+
+#[derive(Debug)]
+pub struct MsmsIsolationWindow {
+    pub scan_start: usize,
+    pub scan_end: usize,
+    pub mz_center: f64,
+    pub mz_width: f64,
 }
 
 impl ReadableFromSql for DiaFramesMsMsTable {
@@ -23,5 +33,64 @@ impl ReadableFromSql for DiaFramesMsMsTable {
             mz_width: sql_reader
                 .read_column_from_table("IsolationWidth", table_name),
         }
+    }
+}
+
+impl DiaFramesMsMsTable {
+    /// Returns a HashMap of MsmsIsolationWindow objects, grouped by group number.
+    /// 
+    /// # Example
+    /// let tbl = DiaFramesMsMsTable{
+    ///     group: vec![1, 1, 2, 2, 2, 3, 3, 3],
+    ///     scan_start: vec![1, 20, 15, 30, 45, 1, 20, 30],
+    ///     scan_end: vec![10, 30, 25, 40, 55, 19, 29, 40],
+    ///     mz_center: vec![100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0],
+    ///     mz_width: vec![40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0],
+    /// };
+    /// let hashmap = tbl.as_hashmap();
+    /// assert_eq!(hashmap.len(), 3);
+    /// assert_eq!(hashmap.get(&1).unwrap().len(), 2);
+    /// assert_eq!(hashmap.get(&2).unwrap().len(), 3);
+    pub fn as_hashmap(&self) -> HashMap<usize, Vec<MsmsIsolationWindow>> {
+        let mut hashmap: HashMap<usize, Vec<MsmsIsolationWindow>> =
+            HashMap::new();
+        for (index, &group) in self.group.iter().enumerate() {
+            let scan_start: usize = self.scan_start[index] as usize;
+            let scan_end: usize = self.scan_end[index] as usize;
+            let mz_center: f64 = self.mz_center[index];
+            let mz_width: f64 = self.mz_width[index];
+            let window: MsmsIsolationWindow = MsmsIsolationWindow {
+                scan_start,
+                scan_end,
+                mz_center,
+                mz_width,
+            };
+            if hashmap.contains_key(&group) {
+                hashmap.get_mut(&group).unwrap().push(window);
+            } else {
+                hashmap.insert(group, vec![window]);
+            }
+        }
+        hashmap
+
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn hashmap_works(){
+        use crate::file_readers::common::sql_reader::DiaFramesMsMsTable;
+        let tbl = DiaFramesMsMsTable{
+            group: vec![1, 1, 2, 2, 2, 3, 3, 3],
+            scan_start: vec![1, 20, 15, 30, 45, 1, 20, 30],
+            scan_end: vec![10, 30, 25, 40, 55, 19, 29, 40],
+            mz_center: vec![100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0],
+            mz_width: vec![40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0],
+        };
+        let hashmap = tbl.as_hashmap();
+        assert_eq!(hashmap.len(), 3);
+        assert_eq!(hashmap.get(&1).unwrap().len(), 2);
+        assert_eq!(hashmap.get(&2).unwrap().len(), 3);
     }
 }

--- a/src/file_readers/common/sql_reader/tables/dia_frames_msms.rs
+++ b/src/file_readers/common/sql_reader/tables/dia_frames_msms.rs
@@ -38,7 +38,7 @@ impl ReadableFromSql for DiaFramesMsMsTable {
 
 impl DiaFramesMsMsTable {
     /// Returns a HashMap of MsmsIsolationWindow objects, grouped by group number.
-    /// 
+    ///
     /// # Example
     /// let tbl = DiaFramesMsMsTable{
     ///     group: vec![1, 1, 2, 2, 2, 3, 3, 3],
@@ -72,20 +72,21 @@ impl DiaFramesMsMsTable {
             }
         }
         hashmap
-
     }
 }
 
 #[cfg(test)]
 mod tests {
     #[test]
-    fn hashmap_works(){
+    fn hashmap_works() {
         use crate::file_readers::common::sql_reader::DiaFramesMsMsTable;
-        let tbl = DiaFramesMsMsTable{
+        let tbl = DiaFramesMsMsTable {
             group: vec![1, 1, 2, 2, 2, 3, 3, 3],
             scan_start: vec![1, 20, 15, 30, 45, 1, 20, 30],
             scan_end: vec![10, 30, 25, 40, 55, 19, 29, 40],
-            mz_center: vec![100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0],
+            mz_center: vec![
+                100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0,
+            ],
             mz_width: vec![40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0],
         };
         let hashmap = tbl.as_hashmap();

--- a/src/file_readers/frame_readers.rs
+++ b/src/file_readers/frame_readers.rs
@@ -1,4 +1,4 @@
-use crate::Frame;
+use crate::{Frame, FrameType};
 
 use self::tdf_reader::TDFReader;
 
@@ -11,9 +11,29 @@ pub trait ReadableFrames {
 
     fn read_all_frames(&self) -> Vec<Frame>;
 
-    fn read_all_ms1_frames(&self) -> Vec<Frame>;
-
     fn read_all_ms2_frames(&self) -> Vec<Frame>;
+    
+    fn read_all_ms1_frames(&self) -> Vec<Frame> {
+        // I am assuming this can be over-written if there is a more
+        // performant way to do this for a specific file format.
+        let frames: Vec<Frame> = self.read_all_frames();
+        let ms1_frames: Vec<Frame> = frames
+            .into_iter()
+            .filter(|frame| frame.frame_type == FrameType::MS1)
+            .collect();
+        ms1_frames
+    }
+
+    fn read_all_dia_frames(&self) -> Vec<Frame> {
+        // I am assuming this can be over-written if there is a more
+        // performant way to do this for a specific file format.
+        let frames: Vec<Frame> = self.read_all_frames();
+        let dia_frames: Vec<Frame> = frames
+            .into_iter()
+            .filter(|frame| frame.frame_type == FrameType::MS2DIA)
+            .collect();
+        dia_frames
+    }
 }
 
 impl FileFormat {

--- a/src/file_readers/frame_readers.rs
+++ b/src/file_readers/frame_readers.rs
@@ -2,6 +2,7 @@ use crate::{Frame, FrameType};
 
 use self::tdf_reader::TDFReader;
 
+use crate::acquisition::AcquisitionType;
 use super::file_formats::FileFormat;
 
 pub mod tdf_reader;
@@ -10,8 +11,6 @@ pub trait ReadableFrames {
     fn read_single_frame(&self, index: usize) -> Frame;
 
     fn read_all_frames(&self) -> Vec<Frame>;
-
-    fn read_all_ms2_frames(&self) -> Vec<Frame>;
 
     fn read_all_ms1_frames(&self) -> Vec<Frame> {
         // I am assuming this can be over-written if there is a more
@@ -22,6 +21,19 @@ pub trait ReadableFrames {
             .filter(|frame| frame.frame_type == FrameType::MS1)
             .collect();
         ms1_frames
+    }
+
+    fn read_all_ms2_frames(&self) -> Vec<Frame> {
+        // I am assuming this can be over-written if there is a more
+        // performant way to do this for a specific file format.
+        let frames: Vec<Frame> = self.read_all_frames();
+        let dia_frames: Vec<Frame> = frames
+            .into_iter()
+            .filter(|frame| {
+                frame.frame_type == FrameType::MS2(AcquisitionType::DDAPASEF)
+            })
+            .collect();
+        dia_frames
     }
 
     fn read_all_dia_frames(&self) -> Vec<Frame> {
@@ -69,5 +81,9 @@ impl ReadableFrames for FileFormat {
 
     fn read_all_ms2_frames(&self) -> Vec<Frame> {
         self.unwrap_frame_reader().read_all_ms2_frames()
+    }
+
+    fn read_all_dia_frames(&self) -> Vec<Frame> {
+        self.unwrap_frame_reader().read_all_dia_frames()
     }
 }

--- a/src/file_readers/frame_readers.rs
+++ b/src/file_readers/frame_readers.rs
@@ -2,8 +2,8 @@ use crate::{Frame, FrameType};
 
 use self::tdf_reader::TDFReader;
 
-use crate::acquisition::AcquisitionType;
 use super::file_formats::FileFormat;
+use crate::acquisition::AcquisitionType;
 
 pub mod tdf_reader;
 

--- a/src/file_readers/frame_readers.rs
+++ b/src/file_readers/frame_readers.rs
@@ -12,7 +12,7 @@ pub trait ReadableFrames {
     fn read_all_frames(&self) -> Vec<Frame>;
 
     fn read_all_ms2_frames(&self) -> Vec<Frame>;
-    
+
     fn read_all_ms1_frames(&self) -> Vec<Frame> {
         // I am assuming this can be over-written if there is a more
         // performant way to do this for a specific file format.
@@ -30,7 +30,10 @@ pub trait ReadableFrames {
         let frames: Vec<Frame> = self.read_all_frames();
         let dia_frames: Vec<Frame> = frames
             .into_iter()
-            .filter(|frame| frame.frame_type == FrameType::MS2DIA)
+            .filter(|frame| {
+                frame.frame_type
+                    == FrameType::MS2(crate::AcquisitionType::DIAPASEF)
+            })
             .collect();
         dia_frames
     }

--- a/src/file_readers/frame_readers/tdf_reader.rs
+++ b/src/file_readers/frame_readers/tdf_reader.rs
@@ -114,7 +114,9 @@ impl ReadableFrames for TDFReader {
             .map(|index| match self.frame_types[index] {
                 FrameType::MS2(_) => self.read_single_frame(index),
                 _ => Frame::default(),
-            })
+            }).collect()
+    }
+    
     fn read_all_dia_frames(&self) -> Vec<Frame> {
         let dia_frame_ids: Vec<usize> = self.dia_frame_table.frame.clone();
         dia_frame_ids

--- a/src/file_readers/frame_readers/tdf_reader.rs
+++ b/src/file_readers/frame_readers/tdf_reader.rs
@@ -118,9 +118,10 @@ impl ReadableFrames for TDFReader {
             .map(|index| match self.frame_types[index] {
                 FrameType::MS2(_) => self.read_single_frame(index),
                 _ => Frame::default(),
-            }).collect()
+            })
+            .collect()
     }
-    
+
     fn read_all_dia_frames(&self) -> Vec<Frame> {
         let dia_frame_ids: Vec<usize> = self.dia_frame_table.frame.clone();
         dia_frame_ids

--- a/src/file_readers/frame_readers/tdf_reader.rs
+++ b/src/file_readers/frame_readers/tdf_reader.rs
@@ -116,13 +116,9 @@ impl ReadableFrames for TDFReader {
             })
     fn read_all_dia_frames(&self) -> Vec<Frame> {
         let dia_frame_ids: Vec<usize> = self.dia_frame_table.frame.clone();
-        let dia_frame_ids: Vec<usize> = dia_frame_ids
-            .into_iter()
-            .filter(|&x| x < self.frame_table.id.len())
-            .collect();
         dia_frame_ids
             .into_par_iter()
-            .map(|index| self.read_single_frame(index))
+            .map(|index| self.read_single_frame(index - 1))
             .collect()
     }
 }

--- a/src/file_readers/frame_readers/tdf_reader.rs
+++ b/src/file_readers/frame_readers/tdf_reader.rs
@@ -8,7 +8,9 @@ use {
         file_readers::{
             common::{
                 ms_data_blobs::{BinFileReader, ReadableFromBinFile},
-                sql_reader::{FrameTable, ReadableFromSql, SqlReader},
+                sql_reader::{
+                    DiaFramesInfoTable, FrameTable, ReadableFromSql, SqlReader,
+                },
             },
             ReadableFrames,
         },
@@ -27,7 +29,8 @@ pub struct TDFReader {
     pub im_converter: Scan2ImConverter,
     pub mz_converter: Tof2MzConverter,
     pub frame_table: FrameTable,
-    frame_types: Vec<FrameType>,
+    pub frame_types: Vec<FrameType>,
+    pub dia_frame_table: DiaFramesInfoTable,
 }
 
 impl TDFReader {
@@ -54,6 +57,8 @@ impl TDFReader {
                 _ => FrameType::Unknown,
             })
             .collect();
+        let dia_frames_table: DiaFramesInfoTable =
+            DiaFramesInfoTable::from_sql(&tdf_sql_reader);
         Self {
             path: path.to_string(),
             tdf_bin_reader: tdf_bin_reader,
@@ -63,6 +68,7 @@ impl TDFReader {
             frame_table: frame_table,
             tdf_sql_reader: tdf_sql_reader,
             frame_types: frame_types,
+            dia_frame_table: dia_frames_table,
         }
     }
 

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -13,6 +13,16 @@ pub struct Frame {
     pub frame_type: FrameType,
 }
 
+pub struct FrameMSMSWindow {
+    pub scan_offsets: Vec<u64>,
+    pub tof_indices: Vec<u32>,
+    pub intensities: Vec<u32>,
+    pub frame_index: usize,
+    pub rt: f64,
+    pub window_group: usize,
+    pub scan_start: usize,
+}
+
 /// The kind of frame, determined by acquisition.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum FrameType {

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -1,8 +1,34 @@
 use crate::acquisition::AcquisitionType;
 
-/// A frame with all unprocessed data as it was acquired.
+use std::fmt::Display;
+
 use crate::converters::{ConvertableIndex, Tof2MzConverter};
 
+/// A Frame is a group of scans (subset of frame along IMS).
+/// That are associated to the same collection of ions in the
+/// tims funnel.
+///
+/// * `scan_offsets` - The scan offsets for the frame.
+///     This is a vec of length N, where N is the number
+///     of scans in the frame.
+/// * `tof_indices` - The TOF indices for the frame.
+///     These values are related to the m/z values of the peaks.
+///     This is a vec of length P, where P is the number of peaks
+///     in the frame.
+/// * `intensities` - The intensities for the frame.
+///     This is a vec of the same size as the tof_indices, therefore
+///     each peak is defined by a combination of the tof_index and
+///     the intensity.
+/// * `index` - The index of the frame. This is the index of the
+///     frame in the "parent" tdf file.
+/// * `rt` - The retention time of the frame, in seconds.
+/// * `frame_type` - The type of frame. This is an enum with the
+///     following possible values:
+///     * `MS1` - The frame is an MS1 frame.
+///     * `MS2DDA` - The frame is an MS2 DDA frame.
+///     * `MS2DIA` - The frame is an MS2 DIA frame.
+///     * `Unknown` - The frame type is unknown.
+///
 #[derive(Debug, PartialEq, Default)]
 pub struct Frame {
     pub scan_offsets: Vec<u64>,
@@ -13,6 +39,37 @@ pub struct Frame {
     pub frame_type: FrameType,
 }
 
+impl Display for Frame {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "(Frame: {}, RT: {}, n_peaks={})",
+            self.index,
+            self.rt,
+            self.tof_indices.len(),
+        )
+    }
+}
+
+/// A Frame window is a group of scans (subset of frame along IMS)
+/// that are associated with a single isolation window.
+///
+/// * `scan_offsets` - The scan offsets for the frame window.
+/// * `tof_indices` - The TOF indices for the frame window.
+///     These values are correlated with the m/z values of the peaks
+///     but are kept as u32 to save space (converting them makes them f64).
+/// * `intensities` - The intensities for the frame window.
+/// * `frame_index` - The index of the frame.
+/// * `rt` - The retention time of the frame.
+/// * `window_group` - The window group of the frame window.
+///     This is an integer value that originally comes from the "WindowGroup"
+///     in the `dia_frame_msms_table` of the TDF file.
+/// * `scan_start` - The index of the first scan in the frame window.
+///     This is used to know what offset to use when converting ims
+///     values from the scan offsets (this number should converted
+///     to mobility and all other mobility values within this frame window
+///     should have that added).
+#[derive(Debug, PartialEq)]
 pub struct FrameMSMSWindow {
     pub scan_offsets: Vec<u64>,
     pub tof_indices: Vec<u32>,
@@ -21,6 +78,19 @@ pub struct FrameMSMSWindow {
     pub rt: f64,
     pub window_group: usize,
     pub scan_start: usize,
+}
+
+impl Display for FrameMSMSWindow {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "(Frame: {}, Window: {}, RT:{}, npeaks={})",
+            self.frame_index,
+            self.window_group,
+            self.rt,
+            self.tof_indices.len(),
+        )
+    }
 }
 
 /// The kind of frame, determined by acquisition.
@@ -38,6 +108,12 @@ impl Default for FrameType {
 }
 
 impl Frame {
+    /// Resolves the m/z values for the frame.
+    ///
+    /// * `mz_reader` - The TOF to m/z converter.
+    ///
+    /// # Returns
+    /// A vec with the m/z values for the frame (as f64).
     pub fn resolve_mz_values(&self, mz_reader: &Tof2MzConverter) -> Vec<f64> {
         self.tof_indices
             .iter()

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -29,7 +29,7 @@ use crate::converters::{ConvertableIndex, Tof2MzConverter};
 ///     * `MS2DIA` - The frame is an MS2 DIA frame.
 ///     * `Unknown` - The frame type is unknown.
 ///
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Default, Clone)]
 pub struct Frame {
     pub scan_offsets: Vec<u64>,
     pub tof_indices: Vec<u32>,
@@ -69,7 +69,7 @@ impl Display for Frame {
 ///     values from the scan offsets (this number should converted
 ///     to mobility and all other mobility values within this frame window
 ///     should have that added).
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct FrameMSMSWindow {
     pub scan_offsets: Vec<u64>,
     pub tof_indices: Vec<u32>,

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -1,6 +1,8 @@
 use crate::acquisition::AcquisitionType;
 
 /// A frame with all unprocessed data as it was acquired.
+use crate::converters::{ConvertableIndex, Tof2MzConverter};
+
 #[derive(Debug, PartialEq, Default)]
 pub struct Frame {
     pub scan_offsets: Vec<u64>,
@@ -22,5 +24,14 @@ pub enum FrameType {
 impl Default for FrameType {
     fn default() -> Self {
         Self::Unknown
+    }
+}
+
+impl Frame {
+    pub fn resolve_mz_values(&self, mz_reader: &Tof2MzConverter) -> Vec<f64> {
+        self.tof_indices
+            .iter()
+            .map(|&x| mz_reader.convert(x))
+            .collect()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub use crate::{
     acquisition::AcquisitionType,
     errors::*,
     file_readers::{FileReader, TDFReader},
-    frames::{Frame, FrameType},
+    frames::{Frame, FrameType, FrameMSMSWindow},
     precursors::{Precursor, PrecursorType},
     spectra::Spectrum,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,16 +22,22 @@ mod acquisition;
 mod calibration;
 mod converters;
 mod errors;
-mod file_readers;
+pub mod file_readers;
 mod frames;
 mod precursors;
 mod spectra;
 mod vec_utils;
 
+pub use file_readers::ReadableFrames;
+
+pub use crate::converters::{
+    ConvertableIndex, Frame2RtConverter, Scan2ImConverter, Tof2MzConverter,
+};
+
 pub use crate::{
     acquisition::AcquisitionType,
     errors::*,
-    file_readers::FileReader,
+    file_readers::{FileReader, TDFReader},
     frames::{Frame, FrameType},
     precursors::{Precursor, PrecursorType},
     spectra::Spectrum,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub use crate::{
     acquisition::AcquisitionType,
     errors::*,
     file_readers::{FileReader, TDFReader},
-    frames::{Frame, FrameType, FrameMSMSWindow},
+    frames::{Frame, FrameMSMSWindow, FrameType},
     precursors::{Precursor, PrecursorType},
     spectra::Spectrum,
 };

--- a/tests/spectrum_readers.rs
+++ b/tests/spectrum_readers.rs
@@ -15,7 +15,8 @@ fn minitdf_reader() {
         .to_str()
         .unwrap()
         .to_string();
-    let spectra: Vec<Spectrum> = FileReader::new(file_path).unwrap().read_all_spectra();
+    let spectra: Vec<Spectrum> =
+        FileReader::new(file_path).unwrap().read_all_spectra();
     let expected: Vec<Spectrum> = vec![
         Spectrum {
             mz_values: vec![100.0, 200.002, 300.03, 400.4],
@@ -59,7 +60,8 @@ fn tdf_reader_dda() {
         .to_str()
         .unwrap()
         .to_string();
-    let spectra: Vec<Spectrum> = FileReader::new(file_path).unwrap().read_all_spectra();
+    let spectra: Vec<Spectrum> =
+        FileReader::new(file_path).unwrap().read_all_spectra();
     let expected: Vec<Spectrum> = vec![
         Spectrum {
             mz_values: vec![199.7633445943076],


### PR DESCRIPTION
This PR attempts to improve what can be achieved with the library on the DIA space.

It adds the frame msms window struct, which is meant to represent a section of frame (I envision it being used for all scans that share an isolation window but there is no reason to not use it in other cases).

It also exposes some of the converters to be used externally (RN the frame has very little value, since one cannot convert externally the tof indices to mz values, it would be nice to have access to the implementation inside timsrust, instead of having to re-implement it)

TODO:
1. Testing, I could add a dia acquisition file we use for testing, which comes from just recording idle flow for ~5 seconds using a DIA method.
2. Documentation, let me know if you would like more documentation comments to be added.

Questions:

I noticed that `read_all_ms1_frames` is defined like this:

```
    fn read_all_ms1_frames(&self) -> Vec<Frame> {
         (0..self.tdf_bin_reader.size())
             .into_par_iter()
             .map(|index| match self.frame_types[index] {
                FrameType::MS1 => self.read_single_frame(index),
                _ => Frame::default(),
            })
            .collect()
     }
```

is there any reason why the frames that are not MS1 are kept as default frames? (in contrast to first filtering the indices and returning a vec of only MS1 frames?)

LMK what you think!