### PR TITLE
Fix frame cycle definition calculation

### DIFF
--- a/crates/timsrust-tdf/src/frame_reader/frame_info_reader.rs
+++ b/crates/timsrust-tdf/src/frame_reader/frame_info_reader.rs
@@ -58,7 +58,7 @@ impl FrameInfoReader {
                 offsets.insert(sql_frame.id, sql_frame.binary_offset);
                 let mut frame_info = FrameInfo::from(sql_frame);
                 let cycle_index = if acquisition == AcquisitionType::DIAPASEF {
-                    Some(index / quadrupole_settings.len())
+                    Some(index / (quadrupole_settings.len() + 1))
                 } else {
                     None
                 };


### PR DESCRIPTION
Adjust the frame cycle definition to ensure correct indexing by modifying the divisor in the calculation. This change enhances the accuracy of the frame cycle determination in the context of DIAPASEF acquisition.

