### PR TITLE
Add Windows SDK support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ target/
 *.ipynb
 *.svg
 *libtimsdata.so
+*timsdata.dll
+*timsdata.lib
 *timsdata*/
 *.tdf*
 *.a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "timsrust"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "rayon",
  "thiserror",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "timsrust-sdk"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "libc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ unreachable_pub = "warn"
 [workspace.dependencies]
 # crates
 filemanager = { path = "crates/filemanager", version = "0.1.4", default-features = false }
-timsrust = { path = "crates/timsrust", version = "0.5.4", default-features = false }
+timsrust = { path = "crates/timsrust", version = "0.5.5", default-features = false }
 timsrust-centroid = { path = "crates/timsrust-centroid", version = "0.1.4", default-features = false }
 timsrust-core = { path = "crates/timsrust-core", version = "0.1.4", default-features = false }
 timsrust-mgf = { path = "crates/timsrust-mgf", version = "0.1.4", default-features = false }
 timsrust-minitdf = { path = "crates/timsrust-minitdf", version = "0.1.4", default-features = false }
 timsrust-parquet-spectra = { path = "crates/timsrust-parquet-spectra", version = "0.1.4", default-features = false }
-timsrust-sdk = { path = "crates/timsrust-sdk", version = "0.1.4", default-features = false }
+timsrust-sdk = { path = "crates/timsrust-sdk", version = "0.1.5", default-features = false }
 timsrust-tdf = { path = "crates/timsrust-tdf", version = "0.1.4", default-features = false }
 timsrust-tsf = { path = "crates/timsrust-tsf", version = "0.1.4", default-features = false }
 timsrust-utils = { path = "crates/timsrust-utils", version = "0.1.4", default-features = false }

--- a/crates/timsrust-sdk/Cargo.toml
+++ b/crates/timsrust-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timsrust-sdk"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 build = "build.rs"
 description = "Bruker TimsData SDK bindings for native timsTOF data access"

--- a/crates/timsrust-sdk/build.rs
+++ b/crates/timsrust-sdk/build.rs
@@ -2,12 +2,25 @@ use std::{env, fs, path::PathBuf};
 
 fn main() {
     const LIB_NAME: &str = "timsdata";
-    let lib_so_name = format!("lib{}.so", LIB_NAME);
+
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+
+    // Name of the runtime artifact that must sit next to the final binary.
+    // The import library (`timsdata.lib`) on Windows is only needed at link
+    // time and does not need to be copied to the target dir.
+    let runtime_lib_name = match target_os.as_str() {
+        "linux" => format!("lib{}.so", LIB_NAME),
+        "windows" => format!("{}.dll", LIB_NAME),
+        other => panic!(
+            "timsrust-sdk: unsupported target OS '{}'. Only linux and windows are supported.",
+            other
+        ),
+    };
 
     let crate_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
 
-    // Allow overriding the directory that contains libtimsdata.so via an env var.
-    // This is useful when building against a git dependency where the .so is not
+    // Allow overriding the directory that contains the timsdata library via an env var.
+    // This is useful when building against a git dependency where the library is not
     // committed to the repo (it is gitignored). Example:
     //   TIMSDATA_LIB_DIR=/path/to/timsrust-sdk/lib cargo build --features sdk
     let lib_path = if let Ok(override_dir) = env::var("TIMSDATA_LIB_DIR") {
@@ -16,12 +29,18 @@ fn main() {
         crate_dir.join("lib")
     };
 
-    // Tell Rust where to find libtimsdata.so at build time
+    // Tell Rust where to find the timsdata library at build time.
+    // On Linux this resolves to libtimsdata.so; on Windows MSVC picks up
+    // timsdata.lib (the import library for timsdata.dll) from the same dir.
     println!("cargo:rustc-link-search=native={}", lib_path.display());
     println!("cargo:rustc-link-lib=dylib={}", LIB_NAME);
 
-    // Embed a relative rpath (runtime path)
-    println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
+    // Embed a relative rpath so the .so is found next to the executable at
+    // runtime. This is a GNU-ld flag and only applies on Linux; on Windows
+    // the loader finds timsdata.dll next to the .exe automatically.
+    if target_os == "linux" {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
+    }
 
     // Determine the actual target/<profile> directory Cargo is building into.
     // OUT_DIR is e.g. <target_dir>/build/timsrust-sdk-<hash>/out, so go up 3 levels.
@@ -33,9 +52,9 @@ fn main() {
         .to_path_buf();
 
     // Source file you want to copy
-    let source = lib_path.join(&lib_so_name);
+    let source = lib_path.join(&runtime_lib_name);
     // Destination in the target folder
-    let destination = target_dir.join(&lib_so_name);
+    let destination = target_dir.join(&runtime_lib_name);
     // Create directory if missing
     fs::create_dir_all(&target_dir).unwrap();
     // Copy the file

--- a/crates/timsrust/Cargo.toml
+++ b/crates/timsrust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timsrust"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 description = "A crate to read Bruker timsTOF data"
 license = "Apache-2.0"


### PR DESCRIPTION
Introduce support for the Windows SDK by adding necessary DLL and LIB files. Update package versions for `timsrust` and `timsrust-sdk` to reflect the changes. This enhances compatibility for Windows users.

