### PR TITLE
Auto publish to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,16 @@ jobs:
       - name: Verify the workspace builds before releasing
         run: cargo build --release --workspace --all-targets --exclude timsrust-sdk
 
-      - name: Bump shared version, commit, tag and push
+      - name: Bump shared version, publish to crates.io, commit, tag and push
+        env:
+          # Token used by `cargo publish`; create it on crates.io and store it as
+          # a repository Actions secret (Settings > Secrets and variables > Actions).
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          cargo release patch --workspace --no-publish --no-confirm
-          cargo release patch --workspace --no-publish --no-confirm --execute
+          if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then
+            echo "Missing CARGO_REGISTRY_TOKEN secret; required to publish to crates.io." >&2
+            exit 1
+          fi
+          # Dry-run first to surface problems before anything is published or pushed.
+          cargo release patch --workspace --no-confirm
+          cargo release patch --workspace --no-confirm --execute

--- a/crates/timsrust-sdk/Cargo.toml
+++ b/crates/timsrust-sdk/Cargo.toml
@@ -6,6 +6,14 @@ build = "build.rs"
 description = "Bruker TimsData SDK bindings for native timsTOF data access"
 license = "Apache-2.0"
 
+[package.metadata.release]
+# The proprietary Bruker native SDK is not available on the CI runners, so this
+# crate cannot be built there. Publish the source without a verification build
+# (`cargo publish --no-verify`). Consumers link the real library themselves via
+# the crate's `lib/` directory or the TIMSDATA_LIB_DIR env var; build.rs
+# tolerates a missing library so docs.rs and plain `cargo build` still succeed.
+verify = false
+
 [dependencies]
 timsrust-core = { workspace = true, features = ["io"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/timsrust-sdk/build.rs
+++ b/crates/timsrust-sdk/build.rs
@@ -53,18 +53,34 @@ fn main() {
 
     // Source file you want to copy
     let source = lib_path.join(&runtime_lib_name);
-    // Destination in the target folder
-    let destination = target_dir.join(&runtime_lib_name);
-    // Create directory if missing
-    fs::create_dir_all(&target_dir).unwrap();
-    // Copy the file
-    fs::copy(&source, &destination).unwrap_or_else(|e| {
-        panic!("Failed to copy {:?} to {:?}: {}", source, destination, e)
-    });
 
-    // Logging
-    println!("cargo:warning=Target dir: {}", target_dir.display());
-    println!("cargo:warning=Source dir: {}", source.display());
+    // The runtime library is gitignored and absent when the crate is built
+    // without the proprietary Bruker SDK (e.g. `cargo publish --no-verify`,
+    // docs.rs, or a plain `cargo build` by a downstream user). Skip the copy
+    // instead of failing; real usage requires the library to be present in
+    // `lib/` or pointed at by TIMSDATA_LIB_DIR.
+    if source.exists() {
+        // Destination in the target folder
+        let destination = target_dir.join(&runtime_lib_name);
+        // Create directory if missing
+        fs::create_dir_all(&target_dir).unwrap();
+        // Copy the file
+        fs::copy(&source, &destination).unwrap_or_else(|e| {
+            panic!("Failed to copy {:?} to {:?}: {}", source, destination, e)
+        });
+
+        // Logging
+        println!("cargo:warning=Target dir: {}", target_dir.display());
+        println!("cargo:warning=Source dir: {}", source.display());
+    } else {
+        println!(
+            "cargo:warning=timsrust-sdk: {} not found in {}; skipping runtime library copy. \
+             Set TIMSDATA_LIB_DIR to the directory containing the Bruker timsdata library to link against it.",
+            runtime_lib_name,
+            lib_path.display()
+        );
+    }
+
     // Re-run this script if the file changes
     println!("cargo:rerun-if-changed={}", source.display());
     println!("cargo:rerun-if-env-changed=TIMSDATA_LIB_DIR");


### PR DESCRIPTION
Implement automated publishing to crates.io by adding a token check and modifying the release process to allow for dry runs. Update the package metadata to handle cases where the proprietary SDK is not available during CI builds. This ensures that the crate can still be published without verification while providing necessary warnings for downstream users.

